### PR TITLE
Resolve options warning

### DIFF
--- a/lib/sidekiq/grouping/config.rb
+++ b/lib/sidekiq/grouping/config.rb
@@ -2,7 +2,13 @@ module Sidekiq::Grouping::Config
   include ActiveSupport::Configurable
 
   def self.options
-    Sidekiq.options[:grouping] || Sidekiq.options["grouping"] || {} # sidekiq 5.x use symbol in keys
+    if Sidekiq.respond_to?(:[]) # Sidekiq 6.x
+      Sidekiq[:grouping] || {}
+    elsif Sidekiq.respond_to?(:options) # Sidekiq <= 5.x
+      Sidekiq.options[:grouping] || Sidekiq.options["grouping"] || {}
+    else # Sidekiq 7.x
+      Sidekiq.default_configuration[:grouping] || {}
+    end
   end
 
   # Queue size overflow check polling interval


### PR DESCRIPTION
We are getting a lot of these:

```
WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: [".../lib/sidekiq/grouping/config.rb:5:in `options'", 
```

Sidekiq 6 changed the way options are accessed.

This is [backported from upstream](https://github.com/gzigzigzeo/sidekiq-grouping/blob/7ffa30ee69effd46bc02d74f99622a8791915561/lib/sidekiq/grouping/config.rb). It also supports Sidekiq 7.